### PR TITLE
初步完成卡片简介功能

### DIFF
--- a/web/src/admin/card/index.vue
+++ b/web/src/admin/card/index.vue
@@ -138,7 +138,7 @@ export default {
   },
   methods: {
     getList() {
-      this.loading = true;
+      this.loading = true
       if (this.queryParams.category==='') {
         this.loading = false;
         return;

--- a/web/src/home/components/Sidebar/SidebarItem.vue
+++ b/web/src/home/components/Sidebar/SidebarItem.vue
@@ -25,6 +25,7 @@
 <script>
 import Item from './Item'
 import FixiOSBug from './FixiOSBug'
+import { scrollTo } from '@/utils/scroll-to'
 
 export default {
   name: 'SidebarItem',
@@ -50,8 +51,9 @@ export default {
     return {}
   },
   methods: {
-    menuItemClickHandler(id) {
+    scrollTo(id){
       const rows = document.getElementById(id);
+      console.log(rows);
       rows.scrollIntoView(
         {behavior: 'smooth', block: 'start'});
       const classList = rows.nextSibling.firstChild.classList;
@@ -60,6 +62,16 @@ export default {
         classList.remove('blink-box');
       }, 3200);
     },
+    menuItemClickHandler(id) {
+      if(this.$route.path!=='/card-list'){
+        this.$router.push({path:`/card-list`}).then(
+          scrollTo(id)
+        )
+      }else{
+        scrollTo(id);
+      }
+    },
+
     hasOneShowingChild(children = [], parent) {
       if (!children) {
         children = [];

--- a/web/src/home/components/card-introduction/index.vue
+++ b/web/src/home/components/card-introduction/index.vue
@@ -1,0 +1,117 @@
+<!--该组件用于构建卡片的简介页面-->
+<template>
+  <div class="app-container">
+    <el-row>
+      <el-col :span="18" :xs="24">
+        <el-row>
+          <el-col :span="5" class="card-icon-col">
+            <ivu-avatar v-if="cardsInfos.icon.src"
+                        :shape="cardIconShape"
+                        :src="cardsInfos.icon.src"
+                        class="card-icon"
+            ></ivu-avatar>
+            <ivu-avatar v-else
+                        :shape="cardIconShape"
+                        :style="{background: cardsInfos.icon.color}"
+                        class="card-icon"
+            >{{ cardsInfos.icon.text }}
+            </ivu-avatar>
+          </el-col>
+          <el-col :span="19">
+            <h1>{{ cardsInfos.title }}</h1>
+            <div v-show="cardsInfos.url!=undefined">
+              <el-link icon="el-icon-link" type="primary" @click="linkClickHandler(cardsInfos.url)">直达链接</el-link>
+            </div>
+          </el-col>
+        </el-row>
+        <el-divider></el-divider>
+        <el-row class="card-introduction">
+          <h2>简介</h2>
+          <div>{{ cardsInfos.content }}</div>
+          <div>轮播图</div>
+        </el-row>
+        <el-divider></el-divider>
+        <el-row>
+          <h2>下载</h2>
+        </el-row>
+        <el-divider></el-divider>
+        <el-row>
+          <h2>相关推荐</h2>
+        </el-row>
+      </el-col>
+      <el-col :span="6" :xs="0">
+        <ourself-information></ourself-information>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+<script>
+import { mapGetters } from 'vuex'
+import OurselfInformation from '@/home/components/ourself-information/index.vue'
+
+export default {
+  name: 'card-introduction',
+  components: { OurselfInformation },
+  mounted() {
+    this.getCardAllInfo()
+  },
+  computed: {
+    ...mapGetters([
+      'cardIconShape',
+      'cardSize'
+    ])
+
+  },
+  data() {
+    let routerParamsList = JSON.parse(this.$route.params.list)
+    return {
+      // 遮罩层
+      loading: true,
+      // 卡片详细信息
+      cardsInfos: {
+        title: routerParamsList.title,
+        content: routerParamsList.content,
+        url: routerParamsList.url,
+        icon: {
+          src: routerParamsList.src !== '' ? routerParamsList.icon.src : '',
+          text: routerParamsList.icon.text,
+          color: routerParamsList.icon.color
+        }
+      }
+    }
+  },
+  methods: {
+    linkClickHandler(url) {
+      if (url) {
+        window.open(url)
+      }
+    },
+    getCardAllInfo() {
+      // let routerParamsList = JSON.parse(this.$route.params.list)
+      // this.cardsInfos.title = routerParamsList.cardsInfos.title;
+      this.loading = true
+      console.log(typeof this.$route.params.list, 'list')
+      //let routerParamsList =JSON.parse(this.$route.params.list);
+      //console.log(typeof routerParamsList);
+      console.log(this.cardsInfos.content, '输出')
+      this.loading = false
+      //console.log(routerParamsList.content,"输出");
+    }
+  }
+}
+</script>
+
+
+<style lang="scss" scoped>
+.card-icon-col {
+  height: 100%;
+}
+
+.card-icon {
+  vertical-align: middle;
+  width: 100%;
+  height: 100%
+}
+
+
+</style>

--- a/web/src/home/components/card-list/index.vue
+++ b/web/src/home/components/card-list/index.vue
@@ -1,33 +1,48 @@
 <template>
-  <section class="app-main">
-    <router-view></router-view>
-  </section>
+  <div >
+  <div v-for="(category, index) in homeCards" :key="category.id" class="category-main">
+    <div :id="category.id" :class="{'anchor-point-first':index===0}" class="anchor-point"></div>
+    <div v-if="Array.isArray(category.children)&&category.children.length===1" class="category-title">
+      <span v-text="category.name + ' / ' + category.children[0].name"></span>
+    </div>
+    <div v-else class="category-title">
+      <span v-text="category.name"></span>
+    </div>
+    <el-tabs v-if="Array.isArray(category.children)&&category.children.length>1" :value="category.children[0].id">
+      <el-tab-pane v-for="child in category.children" :key="child.id" :label="child.name" :name="child.id" lazy>
+        <category-children :datas="child.cards"></category-children>
+      </el-tab-pane>
+    </el-tabs>
+    <category-children v-else-if="Array.isArray(category.children)&&category.children.length===1"
+                       :datas="category.children[0].cards"
+    >
+    </category-children>
+    <category-children v-else :datas="category.cards"></category-children>
+  </div>
+  <el-empty v-if="homeCards.length<=0" description="没有任何数据"></el-empty>
+  </div>
 </template>
-
 <script>
-
-import CardIntroduction from '@/home/components/card-introduction/index.vue'
-import CardList from '@/home/components/card-list/index.vue'
+import { mapGetters } from 'vuex'
 
 export default {
-  name: 'AppMain',
+  name: 'card-list',
   components: {
-    CardList,
-    CardIntroduction
-  }
+    'category-children': () => import('@/home/components/category-children/index.vue')
+
+  },
+  computed: {
+    ...mapGetters([
+      'homeCards'
+    ])
+  },
+  methods: {}
 }
 </script>
 
-<style lang="scss" scoped>
-.app-main {
-  height: calc(100vh - 60px);
-  width: 100%;
-  position: relative;
-  overflow: auto;
-  background-color: #f5f7f9;
-  padding-top: 20px;
-}
 
+
+<style lang="scss" scoped>
 .category-main {
   .anchor-point {
     position: relative;
@@ -93,7 +108,6 @@ export default {
   }
 }
 </style>
-
 <style lang="scss">
 // fix css style bug in open el-dialog
 //.el-popup-parent--hidden {

--- a/web/src/home/components/category-children/index.vue
+++ b/web/src/home/components/category-children/index.vue
@@ -53,6 +53,9 @@ import {mapGetters} from "vuex";
 
 export default {
   name: "category-children",
+  components: {
+
+  },
   props: {
     datas: {
       type: Array
@@ -66,9 +69,8 @@ export default {
   },
   methods: {
     cardClickHandler(card) {
-      if (card.url) {
-        window.open(card.url);
-      }
+      let params = JSON.stringify(card)
+      this.$router.push({name:'card-introduction',query:{id:card.id},params:{list:params}});
     },
     showQrcodeHandler(url) {
       return `${process.env.VUE_APP_BASE_API}/api/v1/qrcode?url=${encodeURIComponent(url)}`;

--- a/web/src/home/components/ourself-information/index.vue
+++ b/web/src/home/components/ourself-information/index.vue
@@ -1,0 +1,38 @@
+<template>
+  <el-card class="cardWithBg" >
+      <img ref="cardWithBg" class="bg"/>
+    <div class="title">{{title}} </div>
+  </el-card>
+</template>
+<script>
+export default {
+  name: 'ourself-information',
+  mounted(){
+    this.setLogoPathAsBg();
+  },
+  methods:{
+    setLogoPathAsBg(){
+      console.log(this.$store.state.settings.logoPath);
+      this.$refs.cardWithBg.src = this.$store.state.settings.logoPath
+    }
+  },
+  data(){
+    return {
+      title:this.$store.state.settings.title,
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.cardWithBg{
+  background: inherit;
+}
+.bg{
+  width: 100%;
+  display: block;
+}
+.title{
+  text-align: center;
+}
+</style>

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -31,7 +31,20 @@ export const routeList = [
     path: '',
     name: 'home',
     component: () => import('@/home/index.vue'),
+    redirect: '/card-list',
+    children: [
+      {
+        path: '/card-list',
+        component: () => import('@/home/components/card-list/index.vue'),
+      },
+      {
+        path: '/card-introduction',
+        name: 'card-introduction',
+        component: () => import('@/home/components/card-introduction/index.vue'),
+      }
+    ]
   },
+
   {
     path: '/admin',
     name: 'admin',
@@ -53,6 +66,7 @@ export const routeList = [
         path: 'card/apply',
         component: () => import('@/admin/card/apply.vue'),
       },
+
       {
         path: 'role',
         component: () => import('@/admin/role/index.vue'),


### PR DESCRIPTION
该feature为在直接跳转和目标网页间提供一个展示页面，目前已完成一部分功能。现在需要征求主要维护维护者的一些意见：

1. 本功能将当前的直接跳转功能改为两次跳转，大家能否接受；
2.如不能接受，改为加入一个开关，让大家自行决定直接跳转还是二次跳转是否更好；
3.本功能计划后续给卡片增加”标签“字段，让搜索功能变为更实用。但是这需要修改数据库的存储卡片信息的表，希望能得到代码主要维护者的同意

同时，希望代码维护者提供一些帮助：
1.如果能接受这个功能的后续开发，能否对前端的头像组件进行增强？我希望在简介界面的头像组件能自动缩放图像；
