### PR TITLE
当用户退出后，强制跳转到首页

### DIFF
--- a/web/src/home/components/Navbar.vue
+++ b/web/src/home/components/Navbar.vue
@@ -105,12 +105,11 @@ export default {
         type: 'warning'
       }).then(() => {
         this.$store.dispatch('user/LogOut').then(() => {
+
+
+
+
           this.$store.dispatch('settings/loadVersion');
-          // 跳转到首页并强制刷新
-          //浏览器可能会对静态资源进行缓存，为确保页面从服务器重新加载，在URL中添加一个随机参数
-          // 浏览器会认为这是一个新的请求，从而强制从服务器重新加载页面，而不是使用缓存。
-          const randomParam = Math.random().toString(36).substring(7);
-          window.location.href = `/?reload=${randomParam}`;
 
         })
       }).catch(() => {

--- a/web/src/home/components/Navbar.vue
+++ b/web/src/home/components/Navbar.vue
@@ -106,6 +106,12 @@ export default {
       }).then(() => {
         this.$store.dispatch('user/LogOut').then(() => {
           this.$store.dispatch('settings/loadVersion');
+          // 跳转到首页并强制刷新
+          //浏览器可能会对静态资源进行缓存，为确保页面从服务器重新加载，在URL中添加一个随机参数
+          // 浏览器会认为这是一个新的请求，从而强制从服务器重新加载页面，而不是使用缓存。
+          const randomParam = Math.random().toString(36).substring(7);
+          window.location.href = `/?reload=${randomParam}`;
+
         })
       }).catch(() => {
       });

--- a/web/src/store/modules/user.js
+++ b/web/src/store/modules/user.js
@@ -61,8 +61,18 @@ const actions = {
 
   // 退出系统
   LogOut({commit, state}) {
+    // 清空 localStorage 和 sessionStorage
+    localStorage.clear();
+    sessionStorage.clear();
+
+    // // 强制刷新页面
+    // // 跳转到主页并强制刷新
+    window.location.href = '/';
+    window.location.reload(true);
+    
     return http.post('/logout').then(() => {
       window.localStorage.userLogout = true;
+
     })
   },
 }


### PR DESCRIPTION
根据前面的功能点更新-“不允许非登录用户访问后台页面”，当用户退出后应当强制定向到首页并刷新，否则用户可以关闭登录窗口，继续访问(但拿不到数据)后台页面。同时，退出函数logout未执行清理，其他人可能可以在浏览器的应用选项卡下拿到用户的账号密码等信息